### PR TITLE
chore: add project metadata and deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "content-spark"
+version = "0.1.0"
+description = "Content generation orchestrator"
+authors = []
+requires-python = ">=3.11"
+dependencies = [
+    "streamlit",
+    "httpx",
+    "qdrant-client",
+    "tantivy",
+    "pillow",
+    "openai",
+    "google-generativeai",
+    "deepseek",
+    "chromadb",
+    "sqlite",
+    "pytest",
+    "pre-commit",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+streamlit
+httpx
+qdrant-client
+tantivy
+pillow
+openai
+google-generativeai
+deepseek
+chromadb
+sqlite
+pytest
+pre-commit


### PR DESCRIPTION
## Summary
- establish pyproject.toml with Python 3.11 metadata for content-spark
- list project dependencies and dev tools

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68ba0b703118832199bf657be564e7bb